### PR TITLE
enhancement0

### DIFF
--- a/WDBFontOverwrite/vm_unaligned_copy_switch_race.c
+++ b/WDBFontOverwrite/vm_unaligned_copy_switch_race.c
@@ -68,7 +68,7 @@ switcheroo_thread(__unused void *arg)
 		T_QUIET; T_EXPECT_MACH_SUCCESS(kr, " vm_map() RW");
 		/* wait a little bit */
 		usleep(100);
-		/* switch bakc to original RO mapping */
+		/* switch back to original RO mapping */
 		kr = vm_map(mach_task_self(),
 		    &ctx->e0,
 		    ctx->obj_size,


### PR DESCRIPTION
Fixed typos:
bakc -> back

Found with: https://github.com/ss18/grep-typos