### PR TITLE
Removed TTC fix option from Emoji section

### DIFF
--- a/WDBFontOverwrite/ContentView.ViewModel.swift
+++ b/WDBFontOverwrite/ContentView.ViewModel.swift
@@ -19,7 +19,7 @@ extension ContentView {
       var targetPath: String?
       var targetPaths: [String]?
       var localPath: String
-      var alternativeTTCRepackMode: TTCRepackMode
+      var alternativeTTCRepackMode: TTCRepackMode?
     }
     
     final class ViewModel: ObservableObject {
@@ -90,8 +90,7 @@ extension ContentView {
                     "/System/Library/Fonts/CoreAddition/AppleColorEmoji-160px.ttc",
                     "/System/Library/Fonts/Core/AppleColorEmoji.ttc",
                 ],
-                localPath: "CustomAppleColorEmoji.woff2",
-                alternativeTTCRepackMode: .firstFontOnly
+                localPath: "CustomAppleColorEmoji.woff2"
             ),
             CustomFont(
                 name: "PingFang.ttc",

--- a/WDBFontOverwrite/ContentView.swift
+++ b/WDBFontOverwrite/ContentView.swift
@@ -89,13 +89,15 @@ struct ContentView: View {
                 } label: {
                     Text("Import custom \(font.name)")
                 }
-                Button {
-                    viewModel.message = "Importing..."
-                    viewModel.importName = font.localPath
-                    viewModel.importTTCRepackMode = font.alternativeTTCRepackMode
-                    viewModel.importPresented = true
-                } label: {
-                    Text("Import custom \(font.name) with fix for .ttc")
+                if let alternativeTTCRepackMode = font.alternativeTTCRepackMode  {
+                    Button {
+                        viewModel.message = "Importing..."
+                        viewModel.importName = font.localPath
+                        viewModel.importTTCRepackMode = alternativeTTCRepackMode
+                        viewModel.importPresented = true
+                    } label: {
+                        Text("Import custom \(font.name) with fix for .ttc")
+                    }
                 }
             } header: {
                 Text(font.name)


### PR DESCRIPTION
TTC fix (first font only) will remove .AppleColorEmojiUI font from the TTC collection which is used widely in Apple UI apps.